### PR TITLE
build(deps): move @docusaurus/types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "bugs": "https://github.com/dipakparmar/docusaurus-plugin-umami/issues",
   "dependencies": {
     "@docusaurus/core": "3.6.1",
-    "@docusaurus/types": "3.6.1",
     "@docusaurus/utils-validation": "3.6.1",
     "tslib": "^2.4.0"
   },
@@ -43,6 +42,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.0",
+    "@docusaurus/types": "3.6.1",
     "@tsconfig/docusaurus": "^2.0.0",
     "typescript": "~5.6.3"
   }


### PR DESCRIPTION
Hi! Thanks for this nice package.

We are trying to keep our dependencies as clean as possible, and I noticed that this type dependency belongs to dev dependencies.

Also wonder if `@docusaurus/core` is actually needed, it is not imported in any of the TS files?!